### PR TITLE
Update Layerzero example

### DIFF
--- a/contracts/examples/ExampleReceiverDapp.sol
+++ b/contracts/examples/ExampleReceiverDapp.sol
@@ -5,10 +5,12 @@ pragma solidity ^0.8.17;
 import "../interfaces/IMessageReceiver.sol";
 
 contract ExampleReceiverDapp is IMessageReceiver {
-    uint256 public fromChainId;
-    address public localLineAddress;
-    address public fromDappAddress;
-    bytes public message;
+    event DappMessageRecv(
+        uint256 fromChainId,
+        address fromDappAddress,
+        address localLineAddress,
+        bytes message
+    );
 
     function recv(
         uint256 _fromChainId,
@@ -16,9 +18,6 @@ contract ExampleReceiverDapp is IMessageReceiver {
         address _localLineAddress,
         bytes calldata _message
     ) external {
-        fromChainId = _fromChainId;
-        localLineAddress = _localLineAddress;
-        fromDappAddress = _fromDappAddress;
-        message = _message;
+        emit DappMessageRecv(_fromChainId, _fromDappAddress, _localLineAddress, _message);
     }
 }

--- a/contracts/lines/AxelarLine.sol
+++ b/contracts/lines/AxelarLine.sol
@@ -14,7 +14,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 contract AxelarLine is BaseMessageLine, AxelarExecutable, Ownable {
     IAxelarGasService public immutable GAS_SERVICE;
 
-    AxelarChainIdMapping public immutable chainIdMapping;
+    address public immutable chainIdMappingAddress;
 
     constructor(
         address _localMsgportAddress,
@@ -26,7 +26,7 @@ contract AxelarLine is BaseMessageLine, AxelarExecutable, Ownable {
         BaseMessageLine(_localMsgportAddress, _gateway, _metadata)
         AxelarExecutable(_gateway)
     {
-        chainIdMapping = AxelarChainIdMapping(_chainIdMappingAddress);
+        chainIdMappingAddress = _chainIdMappingAddress;
         GAS_SERVICE = IAxelarGasService(_gasReceiver);
     }
 
@@ -57,7 +57,7 @@ contract AxelarLine is BaseMessageLine, AxelarExecutable, Ownable {
             _messagePayload
         );
 
-        string memory toChainId = chainIdMapping.down(_toChainId);
+        string memory toChainId = AxelarChainIdMapping(chainIdMappingAddress).down(_toChainId);
         string memory toLineAddress = Utils.addressToHexString(
             toLineAddressLookup[_toChainId]
         );
@@ -86,7 +86,7 @@ contract AxelarLine is BaseMessageLine, AxelarExecutable, Ownable {
             bytes memory messagePayload
         ) = abi.decode(payload_, (address, address, bytes));
 
-        uint64 fromChainId = chainIdMapping.up(sourceChain_);
+        uint64 fromChainId = AxelarChainIdMapping(chainIdMappingAddress).up(sourceChain_);
         require(
             fromLineAddressLookup[fromChainId] ==
                 Utils.hexStringToAddress(sourceAddress_),

--- a/contracts/lines/AxelarLine.sol
+++ b/contracts/lines/AxelarLine.sol
@@ -44,7 +44,7 @@ contract AxelarLine is BaseMessageLine, AxelarExecutable, Ownable {
         _addFromLine(_fromChainId, _fromLineAddress);
     }
 
-    function _callRemoteRecv(
+    function _send(
         address _fromDappAddress,
         uint64 _toChainId,
         address _toDappAddress,
@@ -93,6 +93,6 @@ contract AxelarLine is BaseMessageLine, AxelarExecutable, Ownable {
             "invalid source line address"
         );
 
-        recv(fromChainId, fromDappAddress, toDappAddress, messagePayload);
+        _recv(fromChainId, fromDappAddress, toDappAddress, messagePayload);
     }
 }

--- a/contracts/lines/CelerLine.sol
+++ b/contracts/lines/CelerLine.sol
@@ -41,7 +41,7 @@ contract CelerLine is BaseMessageLine, MessageSenderApp, MessageReceiverApp {
     // For sending
     //////////////////////////////////////////
     // override BaseMessageLine
-    function _callRemoteRecv(
+    function _send(
         address _fromDappAddress,
         uint64 _toChainId,
         address _toDappAddress,
@@ -55,7 +55,7 @@ contract CelerLine is BaseMessageLine, MessageSenderApp, MessageReceiverApp {
         );
 
         // https://github.com/celer-network/sgn-v2-contracts/blob/1c65d5538ff8509c7e2626bb1a857683db775231/contracts/message/interfaces/IMessageBus.sol#LL122C17-L122C17
-        uint256 fee = IMessageBus(messageBus).calcFee(celerMessage);
+        uint256 fee = IMessageBus(localMessagingContractAddress).calcFee(celerMessage);
 
         // check fee payed by caller is enough.
         uint256 paid = msg.value;
@@ -84,19 +84,22 @@ contract CelerLine is BaseMessageLine, MessageSenderApp, MessageReceiverApp {
         uint64 _srcChainId,
         bytes calldata _celerMessage,
         address // executor
-    ) external payable override onlyMessageBus returns (ExecutionStatus) {
+    ) external payable override returns (ExecutionStatus) {
         (
             address fromDappAddress,
             address toDappAddress,
             bytes memory messagePayload
         ) = abi.decode((_celerMessage), (address, address, bytes));
         uint64 fromChainId = CelerChainIdMapping(chainIdMappingAddress).up(_srcChainId);
+
+        require(msg.sender == localMessagingContractAddress, "caller is not message bus");
+
         require(
             fromLineAddressLookup[fromChainId] == _srcContract,
             "invalid source line address"
         );
 
-        recv(fromChainId, fromDappAddress, toDappAddress, messagePayload);
+        _recv(fromChainId, fromDappAddress, toDappAddress, messagePayload);
 
         return ExecutionStatus.Success;
     }

--- a/contracts/lines/CelerLine.sol
+++ b/contracts/lines/CelerLine.sol
@@ -12,7 +12,7 @@ import "../utils/Utils.sol";
 
 contract CelerLine is BaseMessageLine, MessageSenderApp, MessageReceiverApp {
     address public remoteLineAddress;
-    CelerChainIdMapping public immutable chainIdMapping;
+    address public immutable chainIdMappingAddress;
 
     constructor(
         address _localMsgportAddress,
@@ -20,7 +20,7 @@ contract CelerLine is BaseMessageLine, MessageSenderApp, MessageReceiverApp {
         address _messageBus,
         Metadata memory _metadata
     ) BaseMessageLine(_localMsgportAddress, _messageBus, _metadata) {
-        chainIdMapping = CelerChainIdMapping(_chainIdMappingAddress);
+        chainIdMappingAddress = _chainIdMappingAddress;
     }
 
     function addToLine(
@@ -68,7 +68,7 @@ contract CelerLine is BaseMessageLine, MessageSenderApp, MessageReceiverApp {
 
         sendMessage(
             toLineAddressLookup[_toChainId],
-            chainIdMapping.down(_toChainId),
+            CelerChainIdMapping(chainIdMappingAddress).down(_toChainId),
             celerMessage,
             fee
         );
@@ -90,7 +90,7 @@ contract CelerLine is BaseMessageLine, MessageSenderApp, MessageReceiverApp {
             address toDappAddress,
             bytes memory messagePayload
         ) = abi.decode((_celerMessage), (address, address, bytes));
-        uint64 fromChainId = chainIdMapping.up(_srcChainId);
+        uint64 fromChainId = CelerChainIdMapping(chainIdMappingAddress).up(_srcChainId);
         require(
             fromLineAddressLookup[fromChainId] == _srcContract,
             "invalid source line address"

--- a/contracts/lines/DarwiniaLine.sol
+++ b/contracts/lines/DarwiniaLine.sol
@@ -37,7 +37,7 @@ contract DarwiniaLine is BaseMessageLine, ICrossChainFilter, Ownable2Step {
     // override BaseMessageLine
     //////////////////////////////////////////
     // For sending
-    function _callRemoteRecv(
+    function _send(
         address _fromDappAddress,
         uint64 _toChainId,
         address _toDappAddress,

--- a/contracts/lines/DarwiniaS2SLine.sol
+++ b/contracts/lines/DarwiniaS2SLine.sol
@@ -30,7 +30,7 @@ contract DarwiniaS2sLine is BaseMessageLine, Ownable2Step {
         _addFromLine(_remoteChainId, _remoteLineAddress);
     }
 
-    function _callRemoteRecv(
+    function _send(
         address _fromDappAddress,
         uint64 _toChainId,
         address _toDappAddress,

--- a/contracts/lines/LayerZeroLine.sol
+++ b/contracts/lines/LayerZeroLine.sol
@@ -36,7 +36,7 @@ contract LayerZeroLine is BaseMessageLine, NonblockingLzApp {
         _addFromLine(_fromChainId, _fromLineAddress);
     }
 
-    function _callRemoteRecv(
+    function _send(
         address _fromDappAddress,
         uint64 _toChainId,
         address _toDappAddress,
@@ -83,6 +83,6 @@ contract LayerZeroLine is BaseMessageLine, NonblockingLzApp {
             "invalid source line address"
         );
 
-        recv(srcChainId, fromDappAddress, toDappAddress, messagePayload);
+        _recv(srcChainId, fromDappAddress, toDappAddress, messagePayload);
     }
 }

--- a/contracts/lines/LayerZeroLine.sol
+++ b/contracts/lines/LayerZeroLine.sol
@@ -8,18 +8,18 @@ import "../chain-id-mappings/LayerZeroChainIdMapping.sol";
 import "@layerzerolabs/solidity-examples/contracts/lzApp/NonblockingLzApp.sol";
 
 contract LayerZeroLine is BaseMessageLine, NonblockingLzApp {
-    LayerZeroChainIdMapping public immutable chainIdMapping;
+    address public immutable chainIdMappingAddress;
 
     constructor(
         address _localMsgportAddress,
-        address _lzEndpoingAddress,
         address _chainIdMappingAddress,
+        address _lzEndpoingAddress,
         Metadata memory _metadata
     )
         BaseMessageLine(_localMsgportAddress, _lzEndpoingAddress, _metadata)
         NonblockingLzApp(_lzEndpoingAddress)
     {
-        chainIdMapping = LayerZeroChainIdMapping(_chainIdMappingAddress);
+        chainIdMappingAddress = _chainIdMappingAddress;
     }
 
     function addToLine(
@@ -44,7 +44,7 @@ contract LayerZeroLine is BaseMessageLine, NonblockingLzApp {
         bytes memory _params
     ) internal override {
         // set remote line address
-        uint16 remoteChainId = chainIdMapping.down(_toChainId);
+        uint16 remoteChainId = LayerZeroChainIdMapping(chainIdMappingAddress).down(_toChainId);
 
         // build layer zero message
         bytes memory layerZeroMessage = abi.encode(
@@ -69,7 +69,7 @@ contract LayerZeroLine is BaseMessageLine, NonblockingLzApp {
         uint64 /*_nonce*/,
         bytes memory _payload
     ) internal virtual override {
-        uint64 srcChainId = chainIdMapping.up(_srcChainId);
+        uint64 srcChainId = LayerZeroChainIdMapping(chainIdMappingAddress).up(_srcChainId);
         address srcLineAddress = Utils.bytesToAddress(_srcAddress);
 
         (

--- a/contracts/lines/base/BaseMessageLine.sol
+++ b/contracts/lines/base/BaseMessageLine.sol
@@ -83,7 +83,7 @@ abstract contract BaseMessageLine is IMessageLine {
         fromLineAddressLookup[_fromChainId] = _fromLineAddress;
     }
 
-    function _callRemoteRecv(
+    function _send(
         address _fromDappAddress,
         uint64 _toChainId,
         address _toDappAddress,
@@ -101,7 +101,7 @@ abstract contract BaseMessageLine is IMessageLine {
         // check this is called by local msgport
         _requireCalledByMsgport();
 
-        _callRemoteRecv(
+        _send(
             _fromDappAddress,
             _toChainId,
             _toDappAddress,
@@ -110,17 +110,12 @@ abstract contract BaseMessageLine is IMessageLine {
         );
     }
 
-    function recv(
+    function _recv(
         uint64 _fromChainId,
         address _fromDappAddress,
         address _toDappAddress,
         bytes memory _message
-    ) public virtual {
-        require(
-            msg.sender == localMessagingContractAddress,
-            "Line: Only can be called by local messaging contract"
-        );
-
+    ) internal {
         // call local msgport to receive message
         LOCAL_MSGPORT.recv(
             _fromChainId,

--- a/examples/layerzero/0-setup-msgports.js
+++ b/examples/layerzero/0-setup-msgports.js
@@ -2,8 +2,8 @@ const hre = require("hardhat");
 const { deployMsgport } = require("../helper");
 const { ChainId } = require("../../dist/src/index");
 
-// On bnbChainTestnet, msgport deployed to: 0x0B9325BBc7F5Be9cA45bB9A8B5C74EaB97788adF
-// On polygonTestnet, msgport deployed to: 0x0B9325BBc7F5Be9cA45bB9A8B5C74EaB97788adF
+// On bnbChainTestnet, msgport deployed to: 0xE2B08A0cfCcb40eEfd5254814aF02051Fe6a546a
+// On polygonTestnet, msgport deployed to: 0x1D612F014BC3a1e7980dD0aE12D0d3d240864e83
 async function main() {
   const senderChain = "bnbChainTestnet";
   const receiverChain = "polygonTestnet";
@@ -11,14 +11,14 @@ async function main() {
   ///////////////////////////////////////
   hre.changeNetwork(senderChain);
 
-  // deploy fantom msgport
+  // deploy bnbChainTestnet msgport
   let addr = await deployMsgport(ChainId.BNBCHAIN_TESTNET);
   console.log(`On ${senderChain}, msgport deployed to: ${addr}`);
 
   ///////////////////////////////////////
   hre.changeNetwork(receiverChain);
 
-  // deploy moonbaseAlpha msgport
+  // deploy polygonTestnet msgport
   addr = await deployMsgport(ChainId.POLYGON_MUMBAI, { gasLimit: 1500000 });
   console.log(`On ${receiverChain}, msgport deployed to: ${addr}`);
 }

--- a/examples/layerzero/1-deploy-chain-id-mapping.js
+++ b/examples/layerzero/1-deploy-chain-id-mapping.js
@@ -18,7 +18,7 @@ function getChainIdsList() {
       const evmChainId = ChainListId[chainKey];
       const chainId = ChainId[chainKey]; // ChainId: chain key => chain id, and chain id => chain key
       if (evmChainId && chainId) {
-        // console.log(`${chainKey}: ${evmChainId} => ${chainId}`);
+        console.log(`${chainKey}: ${evmChainId} => ${chainId}`);
         msgportChainids.push(evmChainId);
         lzChainIds.push(chainId);
       }
@@ -41,25 +41,15 @@ async function deployChainIdMappingContract(
   let LayerZeroChainIdMapping = await hre.ethers.getContractFactory(
     "LayerZeroChainIdMapping"
   );
-  let layerZeroChainIdMapping = await LayerZeroChainIdMapping.deploy();
+  let layerZeroChainIdMapping = await LayerZeroChainIdMapping.deploy(msgportChainids, lzChainIds);
   await layerZeroChainIdMapping.deployed();
-  await (
-    await layerZeroChainIdMapping.setDownMapping(msgportChainids, lzChainIds, {
-      gasLimit: 1500000,
-    })
-  ).wait();
-  await (
-    await layerZeroChainIdMapping.setUpMapping(lzChainIds, msgportChainids, {
-      gasLimit: 1500000,
-    })
-  ).wait();
   console.log(
     `On ${chainName}, LayerZeroChainIdMapping contract deployed to: ${layerZeroChainIdMapping.address}`
   );
 }
 
-// On bnbChainTestnet, LayerZeroChainIdMapping contract deployed to: 0x7Ac2cd64B0F9DF41694E917CC436D1392ad91152
-// On polygonTestnet, LayerZeroChainIdMapping contract deployed to: 0x26a4fAE216359De954a927dEbaB339C09Dbf7e8e
+// On bnbChainTestnet, LayerZeroChainIdMapping contract deployed to: 0x8D4906C46de7A75eceb7D02B308907596BBEd3bD
+// On polygonTestnet, LayerZeroChainIdMapping contract deployed to: 0xE5119671d15AF42e3665c4d656d44996D7136144
 async function main() {
   const [msgportChainids, lzChainIds] = getChainIdsList();
 

--- a/examples/layerzero/2-setup-lines.js
+++ b/examples/layerzero/2-setup-lines.js
@@ -2,8 +2,8 @@ const hre = require("hardhat");
 const { deployLine } = require("../helper");
 const { ChainId } = require("../../dist/src/index");
 
-// On bnbChainTestnet, LayerZeroLine deployed to: 0x8Eb3088CBC8E60bBF95b828aF6a5fd36aBa02039
-// On polygonTestnet, LayerZeroLine deployed to: 0x29bb0a67bdBFed977cf978DBb89dA64012Fc5CB4
+// On bnbChainTestnet, LayerZeroLine deployed to: 0xB5A96e55De950601E8759dF2Be396eA34dADa717
+// On polygonTestnet, LayerZeroLine deployed to: 0x6Db337cC418d7A0F2230bc0c6B14813149e39615
 // LayerZero Endpoints:
 // https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses
 async function main() {

--- a/examples/layerzero/2-setup-lines.js
+++ b/examples/layerzero/2-setup-lines.js
@@ -2,8 +2,8 @@ const hre = require("hardhat");
 const { deployLine } = require("../helper");
 const { ChainId } = require("../../dist/src/index");
 
-// On bnbChainTestnet, LayerZeroLine deployed to: 0x0C9549C21313cEdEb794816c534Dc71B0D94A21b
-// On polygonTestnet, LayerZeroLine deployed to: 0x0C9549C21313cEdEb794816c534Dc71B0D94A21b
+// On bnbChainTestnet, LayerZeroLine deployed to: 0x8Eb3088CBC8E60bBF95b828aF6a5fd36aBa02039
+// On polygonTestnet, LayerZeroLine deployed to: 0x29bb0a67bdBFed977cf978DBb89dA64012Fc5CB4
 // LayerZero Endpoints:
 // https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses
 async function main() {
@@ -15,11 +15,21 @@ async function main() {
   ///////////////////////////////////////
   hre.changeNetwork(senderChain);
 
-  const senderMsgportAddress = "0x0B9325BBc7F5Be9cA45bB9A8B5C74EaB97788adF"; // <---- This is the sender msgport address from 0-setup-msgports.js
-  const senderChainIdMapping = "0x7Ac2cd64B0F9DF41694E917CC436D1392ad91152"; // <---- This is the sender chain id mapping contract address from 1-deploy-chain-id-mapping.js
+  const senderMsgportAddress = "0xE2B08A0cfCcb40eEfd5254814aF02051Fe6a546a"; // <---- This is the sender msgport address from 0-setup-msgports.js
+  const senderChainIdMapping = "0x8D4906C46de7A75eceb7D02B308907596BBEd3bD"; // <---- This is the sender chain id mapping contract address from 1-deploy-chain-id-mapping.js
   const senderLineName = "LayerZeroLine";
   const senderLineParams = [
     "0x6Fcb97553D41516Cb228ac03FdC8B9a0a9df04A1", // sender lzEndpoint
+    {
+      name: "LayerZeroLine on bnbChainTestnet",
+      provider: "TEST",
+      description: "just for test",
+      feeEstimation: {
+        feeContract: "0x9F33a4809aA708d7a399fedBa514e0A0d15EfA85",
+        feeMethod: "estimating",
+        offChainFeeApi: "http://123456"
+      },
+    }
   ];
 
   const senderLine = await deployLine(
@@ -38,11 +48,21 @@ async function main() {
   ///////////////////////////////////////
   hre.changeNetwork(receiverChain);
 
-  const receiverMsgportAddress = "0x0B9325BBc7F5Be9cA45bB9A8B5C74EaB97788adF"; // <---- This is the receiver msgport address from 0-setup-msgports.js
-  const receiverChainIdMapping = "0x26a4fAE216359De954a927dEbaB339C09Dbf7e8e"; // <---- This is the receiver chain id mapping contract address from 1-deploy-chain-id-mapping.js
+  const receiverMsgportAddress = "0x1D612F014BC3a1e7980dD0aE12D0d3d240864e83"; // <---- This is the receiver msgport address from 0-setup-msgports.js
+  const receiverChainIdMapping = "0xE5119671d15AF42e3665c4d656d44996D7136144"; // <---- This is the receiver chain id mapping contract address from 1-deploy-chain-id-mapping.js
   const receiverLineName = "LayerZeroLine";
   const receiverLineParams = [
     "0xf69186dfBa60DdB133E91E9A4B5673624293d8F8", // receiver lzEndpoint
+    {
+      name: "LayerZeroLine on polygonTestnet",
+      provider: "TEST",
+      description: "just for test",
+      feeEstimation: {
+        feeContract: "0x9F33a4809aA708d7a399fedBa514e0A0d15EfA85",
+        feeMethod: "estimating2",
+        offChainFeeApi: "http://1234562"
+      },
+    }
   ];
 
   const receiverLine = await deployLine(
@@ -61,22 +81,21 @@ async function main() {
   ///////////////////////////////////////
   // Add remote Line to receiver
   await (
-    await receiverLine.newOutboundLane(
+    await receiverLine.addToLine(
       ChainId.BNBCHAIN_TESTNET,
       senderLine.address,
       { gasLimit: 100000 }
-    )
-  ).wait();
-  console.log("1----------");
-  await (
-    await receiverLine.newInboundLane(
-      ChainId.BNBCHAIN_TESTNET,
-      senderLine.address,
-      { gasLimit: 100000 }
-    )
-  ).wait();
+    )).wait()
+  console.log("1. Add toLine for receiverLine");
 
-  console.log("2----------");
+  await (
+    await receiverLine.addFromLine(
+      ChainId.BNBCHAIN_TESTNET,
+      senderLine.address,
+      { gasLimit: 100000 }
+    )).wait()
+  console.log("2. Add fromLine for receiverLine");
+
   let trustedRemote = hre.ethers.utils.solidityPack(
     ["address", "address"],
     [senderLine.address, receiverLine.address]
@@ -90,23 +109,24 @@ async function main() {
 
   // Add remote Line to sender
   hre.changeNetwork(senderChain);
-  console.log("3----------");
   await (
-    await senderLine.newOutboundLane(
+    await senderLine.addToLine(
       ChainId.POLYGON_MUMBAI,
       receiverLine.address,
       { gasLimit: 100000 }
     )
   ).wait();
-  console.log("4----------");
+  console.log("3 Add toLine for senderLine");
+
   await (
-    await senderLine.newInboundLane(
+    await senderLine.addFromLine(
       ChainId.POLYGON_MUMBAI,
       receiverLine.address,
       { gasLimit: 100000 }
     )
   ).wait();
-  console.log("5----------");
+  console.log("4 Add fromLine for senderLine");
+
   let trustedRemote2 = hre.ethers.utils.solidityPack(
     ["address", "address"],
     [receiverLine.address, senderLine.address]

--- a/examples/layerzero/2-setup-lines.js
+++ b/examples/layerzero/2-setup-lines.js
@@ -2,8 +2,8 @@ const hre = require("hardhat");
 const { deployLine } = require("../helper");
 const { ChainId } = require("../../dist/src/index");
 
-// On bnbChainTestnet, LayerZeroLine deployed to: 0xB5A96e55De950601E8759dF2Be396eA34dADa717
-// On polygonTestnet, LayerZeroLine deployed to: 0x6Db337cC418d7A0F2230bc0c6B14813149e39615
+// On bnbChainTestnet, LayerZeroLine deployed to: 0x03836d459E753335F65D79e441ba4354E3a736D4
+// On polygonTestnet, LayerZeroLine deployed to: 0xc19Fab55351240f1d671D344ad15BDF7F34a3138
 // LayerZero Endpoints:
 // https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses
 async function main() {

--- a/examples/layerzero/3-send-message.js
+++ b/examples/layerzero/3-send-message.js
@@ -10,7 +10,8 @@ async function main() {
   // deploy receiver
   ///////////////////////////////////////
   hre.changeNetwork(receiverChain);
-  const receiverAddress = "0xe13084f8fF65B755E37d95F49edbD49ca26feE13"; // await deployReceiver(receiverChain);
+  const receiverAddress = "0xD7226dD7c502D0d3242115e2C23Ed3C79b4A3387"; 
+  // const receiverAddress = await deployReceiver(receiverChain); console.log(receiverAddress);
   const receiverChainId = (await hre.ethers.provider.getNetwork())["chainId"];
   console.log(
     `On ${receiverChain}, chain id: ${receiverChainId}, receiver address: ${receiverAddress}`
@@ -28,7 +29,7 @@ async function main() {
 
   //  2. get the line selection strategy
   const selectLastLine = async (_) =>
-    "0xB5A96e55De950601E8759dF2Be396eA34dADa717"; // <------- change this to the sender line address, see 2-deploy-line.js
+    "0x03836d459E753335F65D79e441ba4354E3a736D4"; // <------- change this to the sender line address, see 2-deploy-line.js
 
   //  3. send message
   // https://layerzero.gitbook.io/docs/evm-guides/advanced/relayer-adapter-parameters

--- a/examples/layerzero/3-send-message.js
+++ b/examples/layerzero/3-send-message.js
@@ -28,7 +28,7 @@ async function main() {
 
   //  2. get the line selection strategy
   const selectLastLine = async (_) =>
-    "0x8Eb3088CBC8E60bBF95b828aF6a5fd36aBa02039"; // <------- change this to the sender line address, see 2-deploy-line.js
+    "0xB5A96e55De950601E8759dF2Be396eA34dADa717"; // <------- change this to the sender line address, see 2-deploy-line.js
 
   //  3. send message
   // https://layerzero.gitbook.io/docs/evm-guides/advanced/relayer-adapter-parameters

--- a/examples/layerzero/3-send-message.js
+++ b/examples/layerzero/3-send-message.js
@@ -23,12 +23,12 @@ async function main() {
   //  1. get msgport
   const msgport = await getMsgport(
     await hre.ethers.getSigner(),
-    "0xeF1c60AB9B902c13585411dC929005B98Ca44541" // <------- change this, see 0-setup-msgports.js
+    "0xE2B08A0cfCcb40eEfd5254814aF02051Fe6a546a" // <------- change this, see 0-setup-msgports.js
   );
 
   //  2. get the line selection strategy
   const selectLastLine = async (_) =>
-    "0x0C9549C21313cEdEb794816c534Dc71B0D94A21b"; // <------- change this to the sender line address, see 2-deploy-line.js
+    "0x8Eb3088CBC8E60bBF95b828aF6a5fd36aBa02039"; // <------- change this to the sender line address, see 2-deploy-line.js
 
   //  3. send message
   // https://layerzero.gitbook.io/docs/evm-guides/advanced/relayer-adapter-parameters

--- a/src/axelar/EstimateFee.ts
+++ b/src/axelar/EstimateFee.ts
@@ -39,8 +39,8 @@ async function buildEstimateFeeFunction(
     params
   ) => {
     console.log(`fromChainId: ${fromChainId}, toChainId: ${toChainId}`);
-    const axelarSrcChainName = await line.chainIdDown(fromChainId);
-    const axelarDstChainName = await line.chainIdDown(toChainId);
+    const axelarSrcChainName = await line.down(fromChainId);
+    const axelarDstChainName = await line.down(toChainId);
     console.log(
       `axelarSrcChainName: ${axelarSrcChainName}, axelarDstChainName: ${axelarDstChainName}`
     );

--- a/src/interfaces/ILine.ts
+++ b/src/interfaces/ILine.ts
@@ -3,8 +3,6 @@ export type ILine = {
 
   getLocalChainId: () => Promise<number>;
 
-  getOutboundLane: (remoteChainId: number) => Promise<any>;
-
   getRemoteLineAddress: (remoteChainId: number) => Promise<string>;
 
   estimateFee: (

--- a/src/layerzero/EstimateFee.ts
+++ b/src/layerzero/EstimateFee.ts
@@ -1,6 +1,7 @@
 import { IEstimateFee } from "../interfaces/IEstimateFee";
 import { ethers } from "ethers";
 import LayerZeroLineContract from "../../artifacts/contracts/lines/LayerZeroLine.sol/LayerZeroLine.json";
+import LayerZeroChainIdMappingContract from "../../artifacts/contracts/chain-id-mappings/LayerZeroChainIdMapping.sol/LayerZeroChainIdMapping.json"
 
 async function buildEstimateFeeFunction(
   provider: ethers.providers.Provider,
@@ -12,7 +13,14 @@ async function buildEstimateFeeFunction(
     LayerZeroLineContract.abi,
     provider
   );
-  const lzEndpointAddress = await senderLine.lzEndpointAddress();
+  // chainIdMapping
+  const chainIdMappingAddress = senderLine.chainIdMappingAddress();
+  const chainIdMapping = new ethers.Contract(
+    chainIdMappingAddress,
+    LayerZeroChainIdMappingContract.abi,
+    provider
+  )
+  const lzEndpointAddress = await senderLine.localMessagingContractAddress();
 
   // endpoint
   const abi = [
@@ -31,8 +39,8 @@ async function buildEstimateFeeFunction(
     params
   ) => {
     console.log(`fromChainId: ${fromChainId}, toChainId: ${toChainId}`);
-    const lzSrcChainId = await senderLine.chainIdDown(fromChainId);
-    const lzDstChainId = await senderLine.chainIdDown(toChainId);
+    const lzSrcChainId = await chainIdMapping.down(fromChainId);
+    const lzDstChainId = await chainIdMapping.down(toChainId);
     console.log(`lzSrcChainId: ${lzSrcChainId}, lzDstChainId: ${lzDstChainId}`);
 
     const payload = ethers.utils.defaultAbiCoder.encode(

--- a/src/line.ts
+++ b/src/line.ts
@@ -39,20 +39,8 @@ async function getLine(
       return await line.getLocalChainId();
     },
 
-    getOutboundLane: async (remoteChainId: number) => {
-      const outboundLane = await line.outboundLanes(remoteChainId);
-      return {
-        fromChainId: await result.getLocalChainId(),
-        fromLineAddress: lineAddress,
-        toChainId: outboundLane["toChainId"],
-        toLineAddress: outboundLane["toLineAddress"],
-        nonce: outboundLane["nonce"],
-      };
-    },
-
     getRemoteLineAddress: async (remoteChainId: number) => {
-      const lane = await line.outboundLanes(remoteChainId);
-      return lane["toLineAddress"];
+      return await line.toLineAddressLookup(remoteChainId);
     },
 
     estimateFee: async (

--- a/src/lineTypeRegistry.ts
+++ b/src/lineTypeRegistry.ts
@@ -4,5 +4,5 @@ export const lineTypeRegistry: Record<string, LineType> = {
   "0x807a3e011DF1785c538Ac6F65252bf740678Ff99": LineType.AxelarTestnet,
   "0x3d5F09572DdD5f52A70c32d0EC6F67b4d18e62bB": LineType.AxelarTestnet,
   "0x0C9549C21313cEdEb794816c534Dc71B0D94A21b": LineType.LayerZero,
-  "0x8Eb3088CBC8E60bBF95b828aF6a5fd36aBa02039": LineType.LayerZero,
+  "0xB5A96e55De950601E8759dF2Be396eA34dADa717": LineType.LayerZero,
 };

--- a/src/lineTypeRegistry.ts
+++ b/src/lineTypeRegistry.ts
@@ -4,5 +4,5 @@ export const lineTypeRegistry: Record<string, LineType> = {
   "0x807a3e011DF1785c538Ac6F65252bf740678Ff99": LineType.AxelarTestnet,
   "0x3d5F09572DdD5f52A70c32d0EC6F67b4d18e62bB": LineType.AxelarTestnet,
   "0x0C9549C21313cEdEb794816c534Dc71B0D94A21b": LineType.LayerZero,
-  "0xB5A96e55De950601E8759dF2Be396eA34dADa717": LineType.LayerZero,
+  "0x03836d459E753335F65D79e441ba4354E3a736D4": LineType.LayerZero,
 };

--- a/src/lineTypeRegistry.ts
+++ b/src/lineTypeRegistry.ts
@@ -4,4 +4,5 @@ export const lineTypeRegistry: Record<string, LineType> = {
   "0x807a3e011DF1785c538Ac6F65252bf740678Ff99": LineType.AxelarTestnet,
   "0x3d5F09572DdD5f52A70c32d0EC6F67b4d18e62bB": LineType.AxelarTestnet,
   "0x0C9549C21313cEdEb794816c534Dc71B0D94A21b": LineType.LayerZero,
+  "0x8Eb3088CBC8E60bBF95b828aF6a5fd36aBa02039": LineType.LayerZero,
 };

--- a/src/msgport.ts
+++ b/src/msgport.ts
@@ -79,12 +79,14 @@ export async function getMsgport(
       const localLine = await result.getLine(toChainId, selectLine);
 
       // Estimate fee through line
-      const fee = await localLine.estimateFee(
+      let fee = await localLine.estimateFee(
         toChainId,
         messagePayload,
         feeMultiplier,
         params
       );
+      fee = Math.ceil(fee);
+      console.log(`estimateFee: ${fee}`)
       const feeBN = ethers.BigNumber.from(`${fee}`);
       console.log(`cross-chain fee: ${fee / 1e18} UNITs.`);
 


### PR DESCRIPTION
Fix #62 

- Rename `_callRemoteRecv` > `_send`
- Make `recv()` internal and remove check called by localMessagingContract. It's called by self in line.
